### PR TITLE
Configuration fixes

### DIFF
--- a/makeModelYearTooltip/configuration.json
+++ b/makeModelYearTooltip/configuration.json
@@ -7,7 +7,7 @@
 		"title": "Make Model Year Tool Tip",
 		"noView": "true",
         "mapScript": {
-            "src": "/map/addin.js"
+            "src": "/makeModelYearTooltip/addin.js"
         }
     }]
 }

--- a/vehicleInfo/calls.js
+++ b/vehicleInfo/calls.js
@@ -36,7 +36,7 @@ function defineMulticallInit(group) {
     [
       "Get",
       {
-        typeName: "EventRule",
+        typeName: "Rule",
       },
     ],
   ]);


### PR DESCRIPTION
Make, Model and Year add-in had incorrect src path, while VehicleInfo was using a deprecated API Endpoint.